### PR TITLE
Ability to add engine size for particular step in batch config

### DIFF
--- a/cli/runner.py
+++ b/cli/runner.py
@@ -35,7 +35,7 @@ def start():
         # load batch config as json string
         batch_config_json = workflow.utils.read(args.batch_config)
         # create engine if it doesn't exist
-        resource_manager.create_engine(args.engine_size)
+        resource_manager.add_engine(args.engine_size)
         # Skip infrastructure setup during recovery
         if not args.recover and not args.recover_step:
             # Create db and disable IVM in case of enabled flag

--- a/rel/batch_config/workflow/workflow.rel
+++ b/rel/batch_config/workflow/workflow.rel
@@ -42,7 +42,7 @@ module batch_workflow_step
 
     def name[s] = json_data[s, :name]
 
-    def engine_size[s] = json_data[s, :engineSize]
+    def engine_size[s] = uppercase[json_data[s, :engineSize]]
 
     def state(s in BatchWorkflowStep, st in BatchWorkflowStepState) {
         state_value(s, str_val) and

--- a/rel/batch_config/workflow/workflow.rel
+++ b/rel/batch_config/workflow/workflow.rel
@@ -42,6 +42,8 @@ module batch_workflow_step
 
     def name[s] = json_data[s, :name]
 
+    def engine_size[s] = json_data[s, :engineSize]
+
     def state(s in BatchWorkflowStep, st in BatchWorkflowStepState) {
         state_value(s, str_val) and
         st_v = ^BatchWorkflowStepStateValue[str_val] and

--- a/rel/batch_config/workflow/workflow.rel
+++ b/rel/batch_config/workflow/workflow.rel
@@ -57,7 +57,7 @@ module batch_workflow_step
     def json_data(s in BatchWorkflowStep, :state, st_v) {
         st_v = batch_workflow_state_value_to_string[ batch_workflow_step_state:id[ state[s] ] ]
     }
-    def json_data(s in BatchWorkflowStep, :execution_time, t) { execution_time(s, t) }
+    def json_data(s in BatchWorkflowStep, :executionTime, t) { execution_time(s, t) }
 
     def json_data(s, rest...) {
         order(s, o) and

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ rai-sdk==0.6.14
 requests==2.31.0
 requests-toolbelt==1.0.0
 urllib3==1.26.6
+more-itertools==10.1.0
 azure-storage-blob==12.17.0

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         "pyarrow==6.0.1",
         "requests==2.31.0",
         "requests-toolbelt==1.0.0",
+        "more-itertools==10.1.0",
         "urllib3==1.26.6",
         "azure-storage-blob==12.17.0"],
     license="http://www.apache.org/licenses/LICENSE-2.0",

--- a/workflow/__init__.py
+++ b/workflow/__init__.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version_info__ = (0, 0, 1)
+__version_info__ = (0, 0, 2)
 __version__ = ".".join(map(str, __version_info__))

--- a/workflow/executor.py
+++ b/workflow/executor.py
@@ -69,7 +69,7 @@ class WorkflowStepFactory:
     def get_step(self, logger: logging.Logger, config: WorkflowConfig, step: dict) -> WorkflowStep:
         idt = step["idt"]
         name = step["name"]
-        engine_size = step.get("engineSize")
+        engine_size = str.upper(step["engineSize"]) if "engineSize" in step else None
         state = WorkflowStepState(step.get("state"))
         timing = step.get("executionTime", 0)
 

--- a/workflow/executor.py
+++ b/workflow/executor.py
@@ -418,6 +418,7 @@ class WorkflowExecutor:
                 if step.engine_size:
                     self.resource_manager.add_engine(step.engine_size)
                     step.execute(self.logger, self.config.env, self.resource_manager.get_rai_config(step.engine_size))
+                    self.resource_manager.remove_engine(step.engine_size)
                 else:
                     step.execute(self.logger, self.config.env, rai_config)
 

--- a/workflow/executor.py
+++ b/workflow/executor.py
@@ -69,9 +69,9 @@ class WorkflowStepFactory:
     def get_step(self, logger: logging.Logger, config: WorkflowConfig, step: dict) -> WorkflowStep:
         idt = step["idt"]
         name = step["name"]
-        engine_size = step.get("engine_size")
+        engine_size = step.get("engineSize")
         state = WorkflowStepState(step.get("state"))
-        timing = step.get("execution_time", 0)
+        timing = step.get("executionTime", 0)
 
         self._validate_params(config, step)
         return self._get_step(logger, config, idt, name, state, timing, engine_size, step)

--- a/workflow/executor.py
+++ b/workflow/executor.py
@@ -69,7 +69,7 @@ class WorkflowStepFactory:
     def get_step(self, logger: logging.Logger, config: WorkflowConfig, step: dict) -> WorkflowStep:
         idt = step["idt"]
         name = step["name"]
-        engine_size = step["engine_size"]
+        engine_size = step.get("engine_size")
         state = WorkflowStepState(step.get("state"))
         timing = step.get("execution_time", 0)
 

--- a/workflow/executor.py
+++ b/workflow/executor.py
@@ -443,7 +443,7 @@ class WorkflowExecutor:
         workflow_info = rai.execute_relation_json(self.logger, rai_config, relation, ignore_problems=True)
         steps = workflow_info["steps"]
         for step in steps:
-            execution_time = step['execution_time']
+            execution_time = step["executionTime"]
             self.logger.info(f"{step['name']} (id={step['idt']}) finished in {format_duration(execution_time)}")
         self.logger.info(f"Total workflow execution time is {format_duration(workflow_info['totalTime'])}")
 

--- a/workflow/manager.py
+++ b/workflow/manager.py
@@ -105,7 +105,7 @@ class ResourceManager:
             self.__logger.info(f"`{size}` isn't managed. Ignore deletion")
         else:
             if self.__engines[size].is_default:
-                raise Exception(f"Can't remove default `{size}` engine from managed engines")
+                self.__logger.warning(f"Can't remove default `{size}` engine from managed engines")
             config = self.get_rai_config(size)
             if rai.engine_exist(self.__logger, config):
                 rai.delete_engine(self.__logger, config)

--- a/workflow/manager.py
+++ b/workflow/manager.py
@@ -23,6 +23,7 @@ class ResourceManager:
     def __init__(self, logger: logging.Logger, rai_config: RaiConfig):
         self.__logger = logger
         self.__rai_config = rai_config
+        self.__engines = {}
 
     def get_rai_config(self, size: str = None) -> RaiConfig:
         config = self.__rai_config

--- a/workflow/manager.py
+++ b/workflow/manager.py
@@ -106,12 +106,13 @@ class ResourceManager:
         else:
             if self.__engines[size].is_default:
                 self.__logger.warning(f"Can't remove default `{size}` engine from managed engines")
-            config = self.get_rai_config(size)
-            if rai.engine_exist(self.__logger, config):
-                rai.delete_engine(self.__logger, config)
             else:
-                self.__logger.warning(f"Can't find `{config.engine}` engine. Ignore deletion")
-            del self.__engines[size]
+                config = self.get_rai_config(size)
+                if rai.engine_exist(self.__logger, config):
+                    rai.delete_engine(self.__logger, config)
+                else:
+                    self.__logger.warning(f"Can't find `{config.engine}` engine. Ignore deletion")
+                del self.__engines[size]
 
     def provision_engine(self, size: str) -> None:
         """

--- a/workflow/manager.py
+++ b/workflow/manager.py
@@ -79,6 +79,7 @@ class ResourceManager:
         :param size:    RAI engine size
         :return:
         """
+        self.__logger.info(f"Trying to add managed engine with `{size}` size.")
         config = self.get_rai_config(size)
         if self.__engines:
             if size in self.__engines:
@@ -99,8 +100,9 @@ class ResourceManager:
         :param size:    RAI engine size
         :return:
         """
+        self.__logger.info(f"Trying to remove managed engine with `{size}` size.")
         if size not in self.__engines:
-            self.__logger.info(f"{size}` isn't manged. Ignore deletion")
+            self.__logger.info(f"`{size}` isn't managed. Ignore deletion")
         else:
             if self.__engines[size].is_default:
                 raise Exception(f"Can't remove default `{size}` engine from managed engines")
@@ -117,6 +119,7 @@ class ResourceManager:
         :param size:    RAI engine size
         :return:
         """
+        self.__logger.info(f"Trying to provision engine with `{size}` size and add to managed.")
         config = self.get_rai_config(size)
         if self.__engines:
             if size in self.__engines:
@@ -124,7 +127,7 @@ class ResourceManager:
                     f"`{size}` already managed: `{self.__engines[size]}`. Provision engine {config.engine}")
                 self.__recreate_engine(config, size)
             else:
-                config.engine = f"wf-manager-{uuid.uuid4()}-{size}"
+                config.engine = f"wf-manager-{size}-{uuid.uuid4()}"
                 self.__logger.info(f"Provision engine `{config.engine}`")
                 self.__create_engine(config, size)
                 self.__engines[size] = EngineMetaInfo(config.engine, size, False)
@@ -142,7 +145,7 @@ class ResourceManager:
         """
         if rai.engine_exist(self.__logger, config):
             rai.delete_engine(self.__logger, config)
-        self.__create_engine(config, size)
+        rai.create_engine(self.__logger, config, size)
 
     def __create_engine(self, config, size: str) -> None:
         """

--- a/workflow/manager.py
+++ b/workflow/manager.py
@@ -85,7 +85,7 @@ class ResourceManager:
             if size in self.__engines:
                 self.__logger.info(f"`{size}` already managed: `{self.__engines[size]}`. Ignore creation")
             else:
-                config.engine = f"wf-manager-{uuid.uuid4()}-{size}"
+                config.engine = self.__generate_engine_name(size)
                 self.__create_engine(config, size)
                 self.__engines[size] = EngineMetaInfo(config.engine, size, False)
         else:
@@ -128,7 +128,7 @@ class ResourceManager:
                     f"`{size}` already managed: `{self.__engines[size]}`. Provision engine {config.engine}")
                 self.__recreate_engine(config, size)
             else:
-                config.engine = f"wf-manager-{size}-{uuid.uuid4()}"
+                config.engine = self.__generate_engine_name(size)
                 self.__logger.info(f"Provision engine `{config.engine}`")
                 self.__create_engine(config, size)
                 self.__engines[size] = EngineMetaInfo(config.engine, size, False)
@@ -156,6 +156,15 @@ class ResourceManager:
         """
         if not rai.engine_exist(self.__logger, config):
             rai.create_engine(self.__logger, config, size)
+
+    @staticmethod
+    def __generate_engine_name(size: str) -> str:
+        """
+        Generate RAI engine name for workflow.
+        :param size:    RAI engine size
+        :return:
+        """
+        return f"wf-manager-{size}-{uuid.uuid4()}"
 
     @staticmethod
     def init(logger: logging.Logger, engine, database, env_vars: dict[str, Any] = MappingProxyType({})):

--- a/workflow/manager.py
+++ b/workflow/manager.py
@@ -79,7 +79,7 @@ class ResourceManager:
         :param size:    RAI engine size
         :return:
         """
-        self.__logger.info(f"Trying to add managed engine with `{size}` size.")
+        self.__logger.info(f"Trying to add engine with `{size}` size to manager.")
         config = self.get_rai_config(size)
         if self.__engines:
             if size in self.__engines:
@@ -100,7 +100,7 @@ class ResourceManager:
         :param size:    RAI engine size
         :return:
         """
-        self.__logger.info(f"Trying to remove managed engine with `{size}` size.")
+        self.__logger.info(f"Trying to remove engine with `{size}` size from manager.")
         if size not in self.__engines:
             self.__logger.info(f"`{size}` isn't managed. Ignore deletion")
         else:
@@ -119,7 +119,7 @@ class ResourceManager:
         :param size:    RAI engine size
         :return:
         """
-        self.__logger.info(f"Trying to provision engine with `{size}` size and add to managed.")
+        self.__logger.info(f"Trying to provision engine with `{size}` size and add to manager.")
         config = self.get_rai_config(size)
         if self.__engines:
             if size in self.__engines:


### PR DESCRIPTION
Workflow resource manager can define multiple engines for execution and provide rai config for for steps which required particular engine size.
The engine which add as a first to managed engines marked as default and can be deleted only during resources clean up process.